### PR TITLE
Fix locale setter + rewrite tests in Swift Testing

### DIFF
--- a/Sources/NaiveDateFormatStyle.swift
+++ b/Sources/NaiveDateFormatStyle.swift
@@ -242,9 +242,10 @@ public extension NaiveDateTime {
         ///
         /// - Parameter locale: The locale to apply to the format style.
         /// - Returns: A new `NaiveDateTime.FormatStyle` with the given locale.
-        public func locale(_ locale: Locale) -> NaiveDate.FormatStyle {
+        public func locale(_ locale: Locale) -> NaiveDateTime.FormatStyle {
             .init(
                 date: date,
+                time: time,
                 locale: locale,
                 calendar: calendar,
                 timeZone: timeZone,

--- a/Tests/NaiveDateFormatStyleTests.swift
+++ b/Tests/NaiveDateFormatStyleTests.swift
@@ -1,46 +1,84 @@
 import Foundation
-import XCTest
+import Testing
 import NaiveDate
 
-@available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-final class NaiveDateFormatStyleTest: XCTestCase {
-    func testFormattedNaiveDateAgainstDate_withoutParameters() throws {
+@Suite
+struct NaiveDateFormatStyleTests {
+    @Test
+    func formattedNaiveDateAgainstDate_withoutParameters() throws {
         let naiveDate = NaiveDate(year: 2024, month: 8, day: 12)
-        let foundationDate = try XCTUnwrap(Calendar.current.date(from: naiveDate))
-        
+        let foundationDate = try #require(Calendar.current.date(from: naiveDate))
+
         let formattedFoundationDate = foundationDate.formatted()
         let formattedNaiveDate = naiveDate.formatted()
 
-        XCTAssertEqual(formattedNaiveDate, formattedFoundationDate)
+        #expect(formattedNaiveDate == formattedFoundationDate)
     }
 
-    func testFormattedNaiveDateAgainstDate_numeric() throws {
+    @Test
+    func formattedNaiveDateAgainstDate_numeric() throws {
         let naiveDate = NaiveDate(year: 2024, month: 8, day: 12)
-        let foundationDate = try XCTUnwrap(Calendar.current.date(from: naiveDate))
-        
+        let foundationDate = try #require(Calendar.current.date(from: naiveDate))
+
         let formattedFoundationDate = foundationDate.formatted(date: .numeric, time: .omitted)
         let formattedNaiveDate = naiveDate.formatted(date: .numeric)
 
-        XCTAssertEqual(formattedNaiveDate, formattedFoundationDate)
+        #expect(formattedNaiveDate == formattedFoundationDate)
     }
 
-    func testFormattedNaiveDateTimeAgainstDate_withoutParameters() throws {
+    @Test
+    func formattedNaiveDateTimeAgainstDate_withoutParameters() throws {
         let naiveDate = NaiveDateTime(date: .init(year: 2024, month: 8, day: 12), time: .init(hour: 5, minute: 3, second: 1))
-        let foundationDate = try XCTUnwrap(Calendar.current.date(from: naiveDate))
-        
+        let foundationDate = try #require(Calendar.current.date(from: naiveDate))
+
         let formattedFoundationDate = foundationDate.formatted()
         let formattedNaiveDate = naiveDate.formatted()
 
-        XCTAssertEqual(formattedNaiveDate, formattedFoundationDate)
+        #expect(formattedNaiveDate == formattedFoundationDate)
     }
 
-    func testFormattedNaiveDateTimeAgainstDate_numeric() throws {
+    @Test
+    func formattedNaiveDateTimeAgainstDate_numeric() throws {
         let naiveDate = NaiveDateTime(date: .init(year: 2024, month: 8, day: 12), time: .init(hour: 5, minute: 3, second: 1))
-        let foundationDate = try XCTUnwrap(Calendar.current.date(from: naiveDate))
-        
+        let foundationDate = try #require(Calendar.current.date(from: naiveDate))
+
         let formattedFoundationDate = foundationDate.formatted(date: .numeric, time: .standard)
         let formattedNaiveDate = naiveDate.formatted(date: .numeric, time: .standard)
 
-        XCTAssertEqual(formattedNaiveDate, formattedFoundationDate)
+        #expect(formattedNaiveDate == formattedFoundationDate)
+    }
+
+    @Test
+    func localeSet_naiveDateTime() throws {
+        let locale = Locale(identifier: "en")
+        let formatStyle = NaiveDateTime.FormatStyle(date: .long, time: .shortened)
+        let sut = formatStyle.locale(locale)
+        let expectedFormatStyle = NaiveDateTime.FormatStyle(date: .long, time: .shortened, locale: locale)
+
+        #expect(sut == expectedFormatStyle)
+
+    }
+
+    @Test
+    func localeSet_naiveDate() throws {
+        let locale = Locale(identifier: "en")
+        let formatStyle = NaiveDate.FormatStyle(date: .long, time: .shortened)
+        let sut = formatStyle.locale(locale)
+        let expectedFormatStyle = NaiveDate.FormatStyle(date: .long, time: .shortened, locale: locale)
+
+        #expect(sut == expectedFormatStyle)
+
+    }
+
+    @Test
+    func localeSet_naiveTime() throws {
+        let locale = Locale(identifier: "en")
+        let formatStyle = NaiveTime.FormatStyle(date: .long, time: .shortened)
+        let sut = formatStyle.locale(locale)
+        let expectedFormatStyle = NaiveTime.FormatStyle(date: .long, time: .shortened, locale: locale)
+
+        #expect(sut == expectedFormatStyle)
+
     }
 }
+

--- a/Tests/NaiveDateFormatterTest.swift
+++ b/Tests/NaiveDateFormatterTest.swift
@@ -1,25 +1,28 @@
 import Foundation
-import XCTest
 import NaiveDate
+import Testing
 
-class NaiveDateFormatterTest: XCTestCase {
+@Suite
+struct NaiveDateFormatterTest {
+    @Test
     func testNaiveTimeFormatter_enUS() {
         let formatter = NaiveDateFormatter {
             $0.locale = Locale(identifier: "en_US")
             $0.timeStyle = .short
         }
 
-        XCTAssertEqual(formatter.string(from: NaiveTime("16:10")!), "4:10 PM")
-        XCTAssertEqual(formatter.string(from: NaiveTime("16:10:15")!), "4:10 PM")
+        #expect(formatter.string(from: NaiveTime("16:10")!) == "4:10 PM")
+        #expect(formatter.string(from: NaiveTime("16:10:15")!) == "4:10 PM")
     }
 
+    @Test
     func testNaiveTimeFormatter_enGB() {
         let formatter = NaiveDateFormatter {
             $0.locale = Locale(identifier: "en_GB")
             $0.timeStyle = .short
         }
 
-        XCTAssertEqual(formatter.string(from: NaiveTime("16:10")!), "16:10")
-        XCTAssertEqual(formatter.string(from: NaiveTime("16:10:15")!), "16:10")
+        #expect(formatter.string(from: NaiveTime("16:10")!) == "16:10")
+        #expect(formatter.string(from: NaiveTime("16:10:15")!) == "16:10")
     }
 }


### PR DESCRIPTION
Hi, this MR fixes what I caused (NaiveDateTime not updating based on user `Environment(\.locale)` + I rewrote tests to Swift Testing)